### PR TITLE
fix: next version will cause the vue latest version 3 to be installed,  will cuase vue and vue-server-renderer packages version mismatch error

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/thonatos/vuepress-theme-egg#readme",
   "dependencies": {
-    "@vuepress/plugin-back-to-top": "next",
-    "@vuepress/plugin-medium-zoom": "next",
+    "@vuepress/plugin-back-to-top": "^1.7.1",
+    "@vuepress/plugin-medium-zoom": "^1.7.1",
     "urllib": "^2.33.3"
   },
   "devDependencies": {


### PR DESCRIPTION
now package.json

```json
"dependencies": {
    "@vuepress/plugin-back-to-top": "next",
    "@vuepress/plugin-medium-zoom": "next",
}
```

`@vuepress/plugin-back-to-top` next version dependency vue3。The next version will cause the vue latest version 3 to be installed,  will cuase vue@3 and vue-server-renderer@2 packages version mismatch error。